### PR TITLE
Add queue and sequent tests

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -9,10 +9,12 @@ type Queue struct {
 }
 
 func NewQueue(limit int) *Queue {
-	q := &Queue{
+	if limit < 1 {
+		return nil
+	}
+	return &Queue{
 		queue: make(chan Message, limit),
 	}
-	return q
 }
 
 func (q *Queue) Dequeue() <-chan Message {
@@ -21,6 +23,14 @@ func (q *Queue) Dequeue() <-chan Message {
 
 func (q *Queue) Enqueue() chan<- Message {
 	return q.queue
+}
+
+func (q *Queue) Len() int {
+	return len(q.queue)
+}
+
+func (q *Queue) Cap() int {
+	return cap(q.queue)
 }
 
 func (q *Queue) Stop() {

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,174 @@
+package seriatim
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/commands"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+)
+
+type msg string
+
+func (m msg) Purged() {
+}
+
+func (m msg) String() string {
+	return string(m)
+}
+
+var failmsg = msg("fail")
+
+type qState struct {
+	size         int
+	elements     []string
+	takenElement string
+}
+
+func (s *qState) TakeFront() {
+	s.takenElement = s.elements[0]
+	s.elements = append(s.elements[:0], s.elements[1:]...)
+}
+
+func (s *qState) PushBack(value string) {
+	s.elements = append(s.elements, value)
+}
+
+func (s *qState) PeekBack() string {
+	return s.elements[s.Len()-1]
+}
+
+func (s *qState) Len() int {
+	return len(s.elements)
+}
+
+func (s *qState) Cap() int {
+	return s.size
+}
+
+func (s *qState) String() string {
+	return fmt.Sprintf("State(size=%d, elements=%v)", s.size, s.elements)
+}
+
+func (q *Queue) State() string {
+	return fmt.Sprintf("%d / %d", q.Len(), q.Cap())
+}
+
+var genDequeueCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Dequeue",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		msg, ok := <-sut.(*Queue).Dequeue()
+		if !ok {
+			return failmsg
+		}
+		return msg
+	},
+	NextStateFunc: func(state commands.State) commands.State {
+		state.(*qState).TakeFront()
+		return state
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return state.(*qState).Len() > 0
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(msg).String() == state.(*qState).takenElement, "Dequeue")
+	},
+})
+
+type enqueueCommand string
+
+func (value enqueueCommand) Run(q commands.SystemUnderTest) commands.Result {
+	q.(*Queue).Enqueue() <- msg(string(value))
+	return msg(value)
+}
+func (value enqueueCommand) NextState(state commands.State) commands.State {
+	state.(*qState).PushBack(string(value))
+	return state
+}
+
+func (enqueueCommand) PreCondition(state commands.State) bool {
+	s := state.(*qState)
+	return s.Len() < s.size
+}
+
+func (enqueueCommand) PostCondition(state commands.State, result commands.Result) *gopter.PropResult {
+	return gopter.NewPropResult(result.(msg).String() == state.(*qState).PeekBack(), "Enqueue")
+}
+
+func (value enqueueCommand) String() string {
+	return fmt.Sprintf("Enqueue(%s)", string(value))
+}
+
+var genEnqueueCommand = gen.AnyString().Map(func(value string) commands.Command {
+	return enqueueCommand(value)
+})
+
+var genLenCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Len",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		return sut.(*Queue).Len()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(int) == state.(*qState).Len(), "Len")
+	},
+})
+
+var genCapCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Cap",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		return sut.(*Queue).Cap()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(int) == state.(*qState).Cap(), "Cap")
+	},
+})
+
+var qCommands = &commands.ProtoCommands{
+	NewSystemUnderTestFunc: func(initialState commands.State) commands.SystemUnderTest {
+		s := initialState.(*qState)
+		q := NewQueue(s.size)
+		for e := range s.elements {
+			q.Enqueue() <- msg(e)
+		}
+		return q
+	},
+	DestroySystemUnderTestFunc: func(sut commands.SystemUnderTest) {
+		sut.(*Queue).Stop()
+	},
+	InitialStateGen: gen.IntRange(1, 30).Map(func(size int) *qState {
+		return &qState{
+			size:     size,
+			elements: make([]string, 0, size),
+		}
+	}),
+	InitialPreConditionFunc: func(state commands.State) bool {
+		s := state.(*qState)
+		return s.Len() >= 0 && s.Len() <= s.size
+	},
+	GenCommandFunc: func(state commands.State) gopter.Gen {
+		return gen.OneGenOf(
+			genDequeueCommand,
+			genEnqueueCommand,
+			genLenCommand,
+			genCapCommand,
+		)
+	},
+}
+
+func TestQueue(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property("queue size cannot be < 1",
+		prop.ForAllNoShrink(
+			func(size int) bool {
+				return NewQueue(size) == nil
+			},
+			gen.IntRange(math.MinInt64, 0),
+		))
+	properties.Property("queue", commands.Prop(qCommands))
+	properties.TestingRun(t)
+}

--- a/sequent.go
+++ b/sequent.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	ErrSequentStop   = errors.New("Sequent stopped")
-	ErrSequentDied   = errors.New("Sequent died")
 	ErrUnknownMethod = errors.New("Unknown method")
 )
 
@@ -118,7 +117,8 @@ func (a *sequent) Call(name string, args ...interface{}) ([]interface{}, error) 
 
 	reply, ok := <-replych
 	if !ok {
-		return nil, ErrSequentDied
+		// sequent terminated and channel closed
+		return nil, ErrSequentStop
 	}
 
 	return processMethodReturns(reply.returns), nil

--- a/sequent.go
+++ b/sequent.go
@@ -65,7 +65,9 @@ type request struct {
 }
 
 func (msg *request) Purged() {
-	close(msg.reply)
+	if msg.reply != nil {
+		close(msg.reply)
+	}
 }
 
 type sequent struct {

--- a/sequent_test.go
+++ b/sequent_test.go
@@ -1,0 +1,400 @@
+package seriatim
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/commands"
+	"github.com/leanovate/gopter/gen"
+)
+
+// For use in testing Crash() method
+var ErrIndexOutOfRange = errors.New("runtime error: index out of range")
+
+// Helper value to exercise properties of a sequent
+type value struct{}
+
+// Callable from the sequent
+func (v *value) Public(result bool) bool {
+	return result
+}
+
+func (v *value) private() {
+	// Should not be callable or castable
+}
+
+// Callable and castable that will terminate the sequent
+func (v *value) Crash() {
+	var a []int
+	a[2] = 2
+}
+
+// Castable from the sequent
+func (v *value) Broadcast(flag bool) {
+}
+
+// To aid in tracking what state a Sequent is in we will use a
+// surrogate SUT that contains a Sequent and a channel to determine
+// when it is terminated.
+type sutSequent struct {
+	Sequent
+	t      chan struct{}
+	reason error
+}
+
+func (s *sutSequent) WaitTerminate() error {
+	// Wait for termination (see SequentTerminated)
+	//
+	// Making termination synchronous allows the test framework to
+	// also track the SUT state because there is no interaction
+	// between the SUT and the state tracking.
+	<-s.t
+	return s.reason
+}
+
+func (s *sutSequent) Terminate(err error) {
+	s.Sequent.Terminate(err)
+	s.WaitTerminate()
+}
+
+func (s *sutSequent) SequentTerminated(err error, id uintptr) {
+	s.reason = err
+	close(s.t)
+}
+
+func NewSUT(term bool) *sutSequent {
+	sut := &sutSequent{
+		t: make(chan struct{}),
+	}
+	sut.Sequent = NewSupervisedSequent(&value{}, sut)
+	if term {
+		sut.Sequent.Terminate(errors.New("NewSUT"))
+		sut.WaitTerminate()
+	}
+	return sut
+}
+
+type sState struct {
+	terminated bool
+}
+
+func (s *sState) Terminated() bool {
+	return s.terminated
+}
+
+func (s *sState) Terminate() {
+	s.terminated = true
+}
+
+func (s *sState) String() string {
+	return fmt.Sprintf("State(terminated=%v)", s.terminated)
+}
+
+func NewState(term bool) *sState {
+	return &sState{
+		terminated: term,
+	}
+}
+
+var genIdCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Id",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		return sut.(*sutSequent).Id()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(uintptr) != 0, "Id")
+	},
+})
+
+var genRunningCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Running",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		return sut.(*sutSequent).Running()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool) != state.(*sState).Terminated(), "Running")
+	},
+})
+
+var genTerminateCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Terminate",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		s := sut.(*sutSequent)
+		s.Terminate(errors.New("genTerminateCommand"))
+		return true
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	NextStateFunc: func(state commands.State) commands.State {
+		state.(*sState).Terminate()
+		return state
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(
+			result.(bool) == state.(*sState).Terminated(),
+			"Terminate")
+	},
+})
+
+var genCallCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Call",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		r, err := sut.(*sutSequent).Call("Public", true)
+		if err != nil || len(r) == 0 {
+			return false
+		}
+		return r[0].(bool)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "Call")
+	},
+})
+
+var genCallMissingParamCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CallMissingParam",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		exp := errors.New("Not enough arguments need 2, have 1")
+		_, err := sut.(*sutSequent).Call("Public")
+		return reflect.DeepEqual(exp, err)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CallMissingParam")
+	},
+})
+
+var genCallWrongParamCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CallWrongParam",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		exp := errors.New("Argument 0 of type string is not assignable type bool")
+		err := sut.(*sutSequent).Cast("Public", "false")
+		return reflect.DeepEqual(exp, err)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CallWrongParam")
+	},
+})
+
+var genCallAfterTerminatedCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CallAfterTerminated",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		_, err := sut.(*sutSequent).Call("Public", true)
+		return reflect.DeepEqual(err, ErrSequentStop)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CallAfterTerminated")
+	},
+})
+
+var genCallUnknownMethodCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CallUnknownMethod",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		_, err := sut.(*sutSequent).Call("private")
+		return reflect.DeepEqual(err, ErrUnknownMethod)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CallUnknownMethod")
+	},
+})
+
+var genCallCrashCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CallCrashMethod",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		if _, err := sut.(*sutSequent).Call("Crash"); err != ErrSequentStop {
+			return false
+		}
+		err := sut.(*sutSequent).WaitTerminate()
+		// Runtime errors are technically a different type, so
+		// just check the error string is what we expect
+		return err.Error() == ErrIndexOutOfRange.Error()
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	NextStateFunc: func(state commands.State) commands.State {
+		state.(*sState).Terminate()
+		return state
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CallCrashMethod")
+	},
+})
+
+var genCastCommand = gen.Const(&commands.ProtoCommand{
+	Name: "Cast",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		err := sut.(*sutSequent).Cast("Broadcast", true)
+		return err == nil
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "Cast")
+	},
+})
+
+var genCastMissingParamCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CastMissingParam",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		exp := errors.New("Not enough arguments need 2, have 1")
+		err := sut.(*sutSequent).Cast("Broadcast")
+		return reflect.DeepEqual(exp, err)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CastMissingParam")
+	},
+})
+
+var genCastWrongParamCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CastWrongParam",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		exp := errors.New("Argument 0 of type string is not assignable type bool")
+		err := sut.(*sutSequent).Cast("Broadcast", "foobar")
+		return reflect.DeepEqual(exp, err)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CastWrongParam")
+	},
+})
+
+var genCastAfterTerminatedCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CastAfterTerminated",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		err := sut.(*sutSequent).Cast("Broadcast", true)
+		return reflect.DeepEqual(err, ErrSequentStop)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CastAfterTerminated")
+	},
+})
+
+var genCastUnknownMethodCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CastUnknownMethod",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		err := sut.(*sutSequent).Cast("private")
+		return reflect.DeepEqual(err, ErrUnknownMethod)
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CastUnknownMethod")
+	},
+})
+
+var genCastCrashCommand = gen.Const(&commands.ProtoCommand{
+	Name: "CastCrashMethod",
+	RunFunc: func(sut commands.SystemUnderTest) commands.Result {
+		if err := sut.(*sutSequent).Cast("Crash"); err != nil {
+			return false
+		}
+		err := sut.(*sutSequent).WaitTerminate()
+		// Runtime errors are technically a different type, so
+		// just check the error string is what we expect
+		return err.Error() == ErrIndexOutOfRange.Error()
+	},
+	PreConditionFunc: func(state commands.State) bool {
+		return !state.(*sState).Terminated()
+	},
+	NextStateFunc: func(state commands.State) commands.State {
+		state.(*sState).Terminate()
+		return state
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		return gopter.NewPropResult(result.(bool), "CastCrashMethod")
+	},
+})
+
+var sCommands = &commands.ProtoCommands{
+	NewSystemUnderTestFunc: func(initialState commands.State) commands.SystemUnderTest {
+		return NewSUT(initialState.(*sState).Terminated())
+	},
+	InitialStateGen: gen.Bool().Map(func(term bool) *sState {
+		return NewState(term)
+	}),
+	GenCommandFunc: func(state commands.State) gopter.Gen {
+		return gen.OneGenOf(
+			genRunningCommand,
+			genIdCommand,
+			genTerminateCommand,
+			genCallCommand,
+			genCallMissingParamCommand,
+			genCallWrongParamCommand,
+			genCallAfterTerminatedCommand,
+			genCallUnknownMethodCommand,
+			genCallCrashCommand,
+			genCastCommand,
+			genCastMissingParamCommand,
+			genCastWrongParamCommand,
+			genCastAfterTerminatedCommand,
+			genCastUnknownMethodCommand,
+			genCastCrashCommand,
+		)
+	},
+}
+
+func TestSequentNilValue(t *testing.T) {
+	s := NewSequent(nil)
+	if s != nil {
+		t.Fatal("Incorrectly created sequent with nil value")
+	}
+}
+
+func TestSupervisedSequent(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	properties := gopter.NewProperties(parameters)
+	properties.Property("Supervised Sequent", commands.Prop(sCommands))
+	properties.TestingRun(t)
+}
+
+func TestSequentTable(t *testing.T) {
+	const (
+		notFunction   = "NotFunction"
+		noParameter   = "NoParameter"
+		notAssignable = "NotAssignable"
+	)
+	// table contrived to hit all the conditions in convertMethods
+	methods := map[string]interface{}{
+		notFunction:   notFunction,
+		noParameter:   func() {},
+		notAssignable: func(bool) {},
+	}
+	s := NewSequentTable(&value{}, methods)
+	if _, err := s.Call(notFunction); !reflect.DeepEqual(err, ErrUnknownMethod) {
+		t.Error("Incorrectly able to call invalid function")
+	}
+	if _, err := s.Call(noParameter); !reflect.DeepEqual(err, ErrUnknownMethod) {
+		t.Error("Incorrectly able to call function without param")
+	}
+	if _, err := s.Call(notAssignable); !reflect.DeepEqual(err, ErrUnknownMethod) {
+		t.Error("Incorrectly able to call unassignable type")
+	}
+}


### PR DESCRIPTION
Resulting test coverage:
- queue.go: 100.0%
- sequent.go: 98.2%

Second commit changes sequent behaviour when the sequent is terminated from by a method call that panics. Now the returned error is the same as if the sequent was terminated when the method call was made.
